### PR TITLE
Fix Django logging

### DIFF
--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -182,3 +182,8 @@ USE_NATIVE_JSONFIELD = True
 
 # Sentry
 SENTRY_DSN = os.getenv('SENTRY_DSN')
+if SENTRY_DSN:
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
+
+    sentry_sdk.init(SENTRY_DSN, integrations=[DjangoIntegration()])

--- a/backend/backend/settings/prod.py
+++ b/backend/backend/settings/prod.py
@@ -37,9 +37,3 @@ DATABASES = {
 
 COMMON_NAME_PREFIX = 'd.wott.local'
 STATIC_URL = 'https://static.wott.io/'
-
-# Sentry
-if SENTRY_DSN:
-    import sentry_sdk
-    from sentry_sdk.integrations.django import DjangoIntegration
-    sentry_sdk.init(SENTRY_DSN,integrations=[DjangoIntegration()])

--- a/backend/backend/settings/stage.py
+++ b/backend/backend/settings/stage.py
@@ -19,9 +19,3 @@ DATABASES = {
 }
 
 COMMON_NAME_PREFIX = 'd.wott-stage.local'
-
-# Sentry
-if SENTRY_DSN:
-    import sentry_sdk
-    from sentry_sdk.integrations.django import DjangoIntegration
-    sentry_sdk.init(SENTRY_DSN,integrations=[DjangoIntegration()])


### PR DESCRIPTION
Fixes #136
Done:
 - setup Sentry support
 - enabled it for prod and stage envs (only if SENTRY_DSN environment variable is available)
 - enabled errors output to console for all environments