### PR TITLE
Fix revoke interaction with device

### DIFF
--- a/backend/device_registry/api_views.py
+++ b/backend/device_registry/api_views.py
@@ -436,7 +436,11 @@ def mtls_creds_view(request, format=None):
         return device_id
 
     device = Device.objects.get(device_id=device_id)
-    serializer = CredentialsListSerializer(device.owner.credentials.all(), many=True)
+    if device.owner:
+        qs = device.owner.credentials.all()
+    else:
+        qs = Credential.objects.none()
+    serializer = CredentialsListSerializer(qs, many=True)
     return Response(serializer.data)
 
 
@@ -528,4 +532,4 @@ def mtls_is_claimed_view(request, format=None):
         return device_id
 
     device = Device.objects.get(device_id=device_id)
-    return Response({'claimed': device.claimed})
+    return Response({'claimed': device.claimed, 'claim_token': device.claim_token})

--- a/backend/device_registry/tests/test_all.py
+++ b/backend/device_registry/tests/test_all.py
@@ -710,6 +710,20 @@ class APICredsTest(APITestCase):
         self.assertListEqual(response.json(), [{'key': 'key1', 'name': 'name1', 'value': 'as9dfyaoiufhoasdfjh',
                                                 'pk': self.credential.pk}])
 
+    def test_get_revoked_device(self):
+        Device.objects.create(device_id='device1.d.wott-dev.local')
+        headers = {
+            'HTTP_SSL_CLIENT_SUBJECT_DN': 'CN=device1.d.wott-dev.local',
+            'HTTP_SSL_CLIENT_VERIFY': 'SUCCESS'
+        }
+        response = self.client.get(
+            self.url,
+            **headers,
+            format='json'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertListEqual(response.json(), [])
+
 
 class APIIsClaimedTest(APITestCase):
     def setUp(self):
@@ -729,4 +743,4 @@ class APIIsClaimedTest(APITestCase):
             format='json'
         )
         self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(response.json(), {'claimed': True})
+        self.assertDictEqual(response.json(), {'claim_token': '', 'claimed': True})

--- a/backend/device_registry/urls.py
+++ b/backend/device_registry/urls.py
@@ -26,7 +26,7 @@ if settings.IS_API:
 # Only load if mTLS
 if settings.IS_MTLS_API:
     urlpatterns += [
-        path('api/{}/sign-csr'.format(api_version),
+        path('api/{}/sign-csr'.format(api_version),  # TODO: change to some unique path.
              api_views.mtls_renew_cert_view,
              name='mtls-sign-device-cert'),
         path('api/{}/ping'.format(api_version),


### PR DESCRIPTION
#261 
Most work is done on the agent side, but few minor api modifications were required:
- fixed the error in returning credentials for revoked devices
- `mtls_is_claimed_view` now returns not only claimed status, but claim token as well
- added one test