### PR TITLE
Increase psycopg2 connection timeout value

### DIFF
--- a/backend/backend/settings/prod.py
+++ b/backend/backend/settings/prod.py
@@ -45,7 +45,7 @@ DATABASES = {
         'HOST': os.getenv('DB_HOST', 'psql'),
         'PORT': os.getenv('DB_PORT', '5432'),
         'OPTIONS': {
-            'connect_timeout': 3,
+            'connect_timeout': 65,
         },
     }
 }


### PR DESCRIPTION
I had to make it longer (65s) than our time allowed to spend on reconnection (60s)