### PR TITLE
Prometheus metrics page access

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -26,6 +26,5 @@ urlpatterns = [
     url(r'^accounts/', include('registration.backends.simple.urls')),
     path('user/', include('profile_page.urls')),
     path('', include('device_registry.urls')),
-    path('monitoring/', include('monitoring.urls')),
-    url('', include('django_prometheus.urls'))
+    path('monitoring/', include('monitoring.urls'))
 ]

--- a/backend/monitoring/urls.py
+++ b/backend/monitoring/urls.py
@@ -1,8 +1,12 @@
 from django.urls import path
 
+from django_prometheus import exports
+from django.contrib.admin.views.decorators import staff_member_required
+
 from .views import CeleryPulseTimestampView, ErrorView
 
 urlpatterns = [
     path('celery/', CeleryPulseTimestampView.as_view(), name='celery_pulse'),
-    path('error/', ErrorView.as_view(), name='error')
+    path('error/', ErrorView.as_view(), name='error'),
+    path('prometheus/', staff_member_required(exports.ExportToDjangoView), name='prometheus-django-metrics')
 ]


### PR DESCRIPTION
Closes #388

Instead of `/metrics` the page will be available at `/monitoring/prometheus/`