### PR TITLE
Fix race condition

### DIFF
--- a/backend/device_registry/celery_tasks/debian_cve.py
+++ b/backend/device_registry/celery_tasks/debian_cve.py
@@ -2,6 +2,7 @@ import logging
 import zlib
 from itertools import groupby
 from urllib.request import urlopen, Request
+import time
 
 from django.conf import settings
 
@@ -16,54 +17,55 @@ def fetch_vulnerabilities():
     """
     Download vulnerability index from Debian Security Tracker, parse it and store in db.
     """
-    vulnerabilities = []
-    for suite in DEBIAN_SUITES:  # Only Debian actual suites currently supported.
-        logger.info('fetching data for "%s".' % suite)
-        url = "https://security-tracker.debian.org/tracker/debsecan/release/1/" + suite
-        response = urlopen(Request(url))
-        compressed_data = response.read()
-        data = zlib.decompress(compressed_data).decode()
+    # Try to acquire the lock.
+    # Spend trying 5m max.
+    # In case of success set the lock's timeout to 10m.
+    redis_conn = redis.Redis(host=settings.REDIS_HOST, port=settings.REDIS_PORT, password=settings.REDIS_PASSWORD)
+    with redis_conn.lock('vulns_lock', timeout=60 * 10, blocking_timeout=60 * 5):
+        time.sleep(60 * 3)  # Sleep 3m to allow all running `update_packages_vulnerabilities` tasks finish.
+        vulnerabilities = []
+        for suite in DEBIAN_SUITES:  # Only Debian actual suites currently supported.
+            logger.info('fetching data for "%s".' % suite)
+            url = "https://security-tracker.debian.org/tracker/debsecan/release/1/" + suite
+            response = urlopen(Request(url))
+            compressed_data = response.read()
+            data = zlib.decompress(compressed_data).decode()
 
-        lines = data.split('\n')
-        lines_split = groupby(lines, lambda e: e.strip() == '')
-        lists = [list(group) for k, group in lines_split if not k]
+            lines = data.split('\n')
+            lines_split = groupby(lines, lambda e: e.strip() == '')
+            lists = [list(group) for k, group in lines_split if not k]
 
-        vuln_name_list, packages_list = lists[:2]
-        if vuln_name_list.pop(0) != 'VERSION 1':
-            logger.error('ERROR')
-        vuln_names = [(name, desc) for (name, flags, desc) in map(lambda x: x.split(',', 2), vuln_name_list)]
+            vuln_name_list, packages_list = lists[:2]
+            if vuln_name_list.pop(0) != 'VERSION 1':
+                logger.error('ERROR')
+            vuln_names = [(name, desc) for (name, flags, desc) in map(lambda x: x.split(',', 2), vuln_name_list)]
 
-        logger.info('parsing data..')
-        for package_desc in packages_list:
-            package, vnum, flags, unstable_version, other_versions = package_desc.split(',', 4)
+            logger.info('parsing data..')
+            for package_desc in packages_list:
+                package, vnum, flags, unstable_version, other_versions = package_desc.split(',', 4)
 
-            other_versions = other_versions.split(' ')
-            if other_versions == ['']:
-                other_versions = []
-            v = Vulnerability(name=vuln_names[int(vnum)][0],
-                              package=package,
-                              unstable_version=unstable_version,
-                              other_versions=other_versions,
-                              is_binary=flags[0] == 'B',
-                              urgency={' ': Vulnerability.Urgency.NONE,
-                                       'L': Vulnerability.Urgency.LOW,
-                                       'M': Vulnerability.Urgency.MEDIUM,
-                                       'H': Vulnerability.Urgency.HIGH
-                                       }[flags[1]],
-                              remote={'?': None,
-                                      'R': True,
-                                      ' ': False
-                                      }[flags[2]],
-                              fix_available=flags[3] == 'F',
-                              os_release_codename=suite)
-            vulnerabilities.append(v)
+                other_versions = other_versions.split(' ')
+                if other_versions == ['']:
+                    other_versions = []
+                v = Vulnerability(name=vuln_names[int(vnum)][0],
+                                  package=package,
+                                  unstable_version=unstable_version,
+                                  other_versions=other_versions,
+                                  is_binary=flags[0] == 'B',
+                                  urgency={' ': Vulnerability.Urgency.NONE,
+                                           'L': Vulnerability.Urgency.LOW,
+                                           'M': Vulnerability.Urgency.MEDIUM,
+                                           'H': Vulnerability.Urgency.HIGH
+                                           }[flags[1]],
+                                  remote={'?': None,
+                                          'R': True,
+                                          ' ': False
+                                          }[flags[2]],
+                                  fix_available=flags[3] == 'F',
+                                  os_release_codename=suite)
+                vulnerabilities.append(v)
 
-        logger.info('saving data...')
-        # Try to acquire the lock.
-        # Spend trying 6m max.
-        # In case of success set the lock's timeout to 5m.
-        redis_conn = redis.Redis(host=settings.REDIS_HOST, port=settings.REDIS_PORT, password=settings.REDIS_PASSWORD)
-        with redis_conn.lock('vulns_lock', timeout=60 * 5, blocking_timeout=60 * 6):
+            logger.info('saving data...')
             Vulnerability.objects.filter(os_release_codename__in=DEBIAN_SUITES).delete()
             Vulnerability.objects.bulk_create(vulnerabilities, batch_size=10000)
             DebPackage.objects.filter(os_release_codename__in=DEBIAN_SUITES).update(processed=False)

--- a/backend/device_registry/tasks.py
+++ b/backend/device_registry/tasks.py
@@ -24,11 +24,11 @@ def send_packages_to_vulns_update():
     return common.send_packages_to_vulns_update(update_packages_vulnerabilities)
 
 
-@shared_task(soft_time_limit=60 * 15, time_limit=60 * 15 + 5)  # Should live 15m max.
+@shared_task(soft_time_limit=60 * 20, time_limit=60 * 20 + 5)  # Should live 20m max.
 def fetch_vulnerabilities_ubuntu():
     return ubuntu_cve.fetch_vulnerabilities()
 
 
-@shared_task(soft_time_limit=60 * 10, time_limit=60 * 10 + 5)  # Should live 10m max.
+@shared_task(soft_time_limit=60 * 15, time_limit=60 * 15 + 5)  # Should live 15m max.
 def fetch_vulnerabilities_debian():
     return debian_cve.fetch_vulnerabilities()


### PR DESCRIPTION
Fixed the race condition that led to integrity errors and deadlocks several previous days at mornings.
Applied the simplest possible solution - we simply make the `fetch_vulnerabilities_debian` and `fetch_vulnerabilities_ubuntu` tasks sleep for 3m before doing their job. This sleep allows all running instances of the `update_packages_vulnerabilities` to finish and everything's gonna be OK because the `send_packages_to_vulns_update` task won't create new messages due to the `vulns_lock` lock.