### PR TITLE
New install instructions

### DIFF
--- a/backend/device_registry/templates/root.html
+++ b/backend/device_registry/templates/root.html
@@ -546,8 +546,8 @@
             console.log('success');
             let title = "To add a node, simply SSH in and run the following commands:";
             let msg = bash_block(
-                   + `$ export CLAIM_TOKEN=${e.key}\n`
-                     `$ curl -sL https://install.wott.io | sudo bash\n`);
+                     `$ export CLAIM_TOKEN="${e.key}"\n`
+                   + `$ curl -sL https://install.wott.io | sudo bash\n`);
             show_dialog(title, msg);
             document.querySelectorAll('pre code').forEach((block) => {
               hljs.highlightBlock(block);


### PR DESCRIPTION
I need a hand here. Right now, Firefox fails with:

```
TypeError: (("$ export CLAIM_TOKEN=" + (intermediate value)) + "\n") is not a function
```