### PR TITLE
FAKE_GITHUB_REPOS_LIST

### DIFF
--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -290,3 +290,5 @@ GITHUB_APP_CLIENT_SECRET = os.getenv('GITHUB_APP_CLIENT_SECRET')    # Github App
 GITHUB_APP_REDIRECT_URL = os.getenv('GITHUB_APP_REDIRECT_URL')    # Github App Redirect URL
 
 MAX_WEEKLY_RA = 5  # The number of RAs for the user to resolve in a week (starting this Monday)
+
+FAKE_GITHUB_REPOS_LIST = True

--- a/backend/device_registry/celery_tasks/github.py
+++ b/backend/device_registry/celery_tasks/github.py
@@ -51,6 +51,16 @@ def list_repos(user_token):
     :return: a dict {id: {owner: ..., name: ..., installation: ..., full_name: ...}}
     :raises GithubError
     """
+    if settings.FAKE_GITHUB_REPOS_LIST:
+        return {fake_id: {
+            'full_name': full_name,
+            'url': 'http://github.com/github/github',
+            'name': name,
+            'owner': 'user',
+            'installation': 1234
+        } for fake_id, full_name, name in [(1, 'fake/fake', 'fake')]}
+    elif settings.FAKE_GITHUB_REPOS_LIST is None:
+        return None
     github = GitHub(paginate=True, sleep_on_ratelimit=False, token=user_token)
     logger.info('getting installations...')
     status, body = github.user.installations.get(headers=HEADERS)

--- a/backend/profile_page/views.py
+++ b/backend/profile_page/views.py
@@ -147,7 +147,8 @@ class WizardCompleteView(LoginRequiredMixin, LoginTrackMixin, APIView):
 class GithubIntegrationView(LoginRequiredMixin, View):
     def get(self, request, *args, **kwargs):
         profile = request.user.profile
-        if None in [settings.GITHUB_APP_ID, settings.GITHUB_APP_PEM, settings.GITHUB_APP_CLIENT_ID,
+        if settings.FAKE_GITHUB_REPOS_LIST is False and \
+                None in [settings.GITHUB_APP_ID, settings.GITHUB_APP_PEM, settings.GITHUB_APP_CLIENT_ID,
                     settings.GITHUB_APP_CLIENT_SECRET, settings.GITHUB_APP_REDIRECT_URL, settings.GITHUB_APP_NAME]:
             context = {'github_authorized': None}
         else:


### PR DESCRIPTION
DO NOT MERGE

[This line](https://github.com/WoTTsecurity/api/pull/625/files#diff-1b8c5e7b1e5990c9d804837c5fe8ea6eR291) controls whether you get fake list (`True`), "Authorize Github" button (`None`) or the real list (`False`)