### PR TITLE
New UI general adjustemnts

### DIFF
--- a/backend/backend/static/scss/_actions.scss
+++ b/backend/backend/static/scss/_actions.scss
@@ -278,7 +278,7 @@
     }
   }
   .btn-group-box {
-    margin: auto;
+    width: 30%;
   }
 
   .recommendation-left-box {

--- a/backend/backend/static/scss/_dropdown.scss
+++ b/backend/backend/static/scss/_dropdown.scss
@@ -120,7 +120,7 @@
   
   .dropdown-nav-block h4 {
    padding-left: 1.3rem;
-   font-size: 1.1rem;
+   font-size: 1rem;
    margin-bottom: 0;
    color: #646d7f;
   }

--- a/backend/device_registry/templates/device_info_overview.html
+++ b/backend/device_registry/templates/device_info_overview.html
@@ -22,12 +22,6 @@
                 <tbody>
                 <div class="d-flex justify-content-between align-items-center wott-table-py bg-white">
                   <h4 class="d-inline-flex wott-table-title">Overview</h4>
-                  <div class="wott-form-group d-flex wott-table-pr">
-                    {% csrf_token %}
-                    <button id="revoke-button" class="btn wott-btn-medium wott-btn-danger mr-3" data-toggle="modal" data-target="#revokeModal" type="button">
-                      Revoke</button>
-                    <button class="btn wott-btn-medium btn-wott-primary" type="submit">Save</button>
-                  </div>
                 </div>
                 <tr>
                   <td class="wott-table-label-lg" scope="row">Hardware Type</td>
@@ -66,6 +60,14 @@
                       {{ form.tags.errors }}
                       {% include "form_field.html" with field=form.tags %}
                     </div>
+                  </td>
+                </tr>
+                <tr class="d-flex justify-content-end">
+                  <td class="wott-form-group pr-3">
+                    {% csrf_token %}
+                    <button id="revoke-button" class="btn wott-btn-medium wott-btn-danger mr-3" data-toggle="modal" data-target="#revokeModal" type="button">
+                      Revoke</button>
+                    <button class="btn wott-btn-medium btn-wott-primary" type="submit">Save</button>
                   </td>
                 </tr>
 

--- a/backend/device_registry/templates/device_info_security.html
+++ b/backend/device_registry/templates/device_info_security.html
@@ -22,7 +22,7 @@
                   <h4 class="wott-table-title wott-table-py">Security</h4>
                   <tr>
                     <th class="wott-table-label" scope="row">Vulnerable Packages</th>
-                    <td class="d-flex justify-content-between w-60">
+                    <td class="d-flex flex-column justify-content-between w-60">
                       {% with object.cve_count as cve_count %}
                         {% if cve_count is None %}
                           <span class="wott-blue font-weight-bold">N/A</span>
@@ -398,7 +398,9 @@
                             {% endif %}
                             {{ ports_form.is_ports_form }}
                             <!-- <select type="select" class="wott-form-control d-block w-50 mb-3"><option>Allow by default</option></select> -->
-                            <button class="btn btn-wott-primary wott-btn-small" type="submit">Apply</button>
+                            <div class="d-flex justify-content-end">
+                              <button class="btn btn-wott-primary wott-btn-small" type="submit">Apply</button>
+                            </div>
                           </div>
                         </form>
                       {% endif %}
@@ -481,7 +483,9 @@
                                 </table>
                               </div>
                               {{ connections_form.is_connections_form }}
-                              <button class="btn btn-wott-primary wott-btn-small" type="submit">Apply</button>
+                              <div class="d-flex justify-content-end">
+                                <button class="btn btn-wott-primary wott-btn-small" type="submit">Apply</button>
+                              </div>
                             </div>
                           </form>
                         {% endif %}


### PR DESCRIPTION
Get apply btn in security tab to the right

Take Revoke and save button down in node overview tab 
![Captura de Tela 2020-02-11 às 11 50 24](https://user-images.githubusercontent.com/48695552/74234490-d17aac00-4cc4-11ea-9cce-b660aae6cada.png)


Stack info high, medium, low in node security tab

![Captura de Tela 2020-02-11 às 11 51 43](https://user-images.githubusercontent.com/48695552/74234555-f96a0f80-4cc4-11ea-8c77-5c07203660e0.png)

Drop-down profile decrease font-size

![Captura de Tela 2020-02-11 às 11 53 31](https://user-images.githubusercontent.com/48695552/74234619-2cac9e80-4cc5-11ea-8b67-f4349fdeb628.png)

More space around btns in RA tab

closes #671, #672, #651