### PR TITLE
Do not display tags that not used as available

### DIFF
--- a/backend/device_registry/api_views.py
+++ b/backend/device_registry/api_views.py
@@ -650,11 +650,7 @@ def autocomplete(request, tag_model):
 
 @login_required
 def autocomplete_tags(request):
-    return autocomplete(
-        request,
-        Tag.objects.filter_or_initial(device__owner=request.user).distinct() |
-        Tag.objects.filter_or_initial(credential__owner=request.user).distinct()
-    )
+    return autocomplete(request, Tag.objects.filter(device__owner=request.user).distinct())
 
 
 class PairingKeysQSMixin(object):
@@ -953,8 +949,7 @@ class DeviceListFilterMixin:
                 if filter_value:
                     filter_value = [unquote(v) for v in filter_value]
                     if len(filter_value) != Tag.objects.filter(device__owner=self.request.user,
-                                                               name__in=filter_value)\
-                                                       .distinct().count():
+                                                               name__in=filter_value).distinct().count():
                         raise ValidationError('tags argument list is invalid.')
 
             if isinstance(query_by, list):

--- a/backend/device_registry/urls.py
+++ b/backend/device_registry/urls.py
@@ -108,11 +108,7 @@ if settings.IS_DASH or settings.IS_CELERY:
         path('devices/<int:device_pk>/actions/', views.RecommendedActionsView.as_view(), name='device_actions'),
         path('cve/', views.CVEView.as_view(), name='cve'),
         path('devices/<int:device_pk>/cve/', views.CVEView.as_view(), name='device_cve'),
-        path(
-            'ajax/tags/autocomplete/',
-            api_views.autocomplete_tags,
-            name='ajax-tags-autocomplete',
-        ),
+        path('ajax/tags/autocomplete/', api_views.autocomplete_tags, name='ajax-tags-autocomplete'),
         path('pairing-keys/',
              views.PairingKeysView.as_view(),
              name='pairing-keys'),


### PR DESCRIPTION
Closes #686

Applied fix supposes we don't use/need credentials functionality any more.