### PR TITLE
Fix position and color for percentage info inside week-progress graph

### DIFF
--- a/backend/backend/static/scss/_dashboard.scss
+++ b/backend/backend/static/scss/_dashboard.scss
@@ -179,7 +179,10 @@
       width: 50%;
     }
   }
-
+  
+  #week-progres-text:after {
+    content: '%';
+  }
 
   #week-progres-text {
     text-align: center;
@@ -187,6 +190,8 @@
     font-size: .6rem;
     z-index: 10;
     font-weight: 800;
+    display: flex;
+    margin-left: 3px;
   }
 
   #week-progress-var p {

--- a/backend/backend/static/scss/_wott-components.scss
+++ b/backend/backend/static/scss/_wott-components.scss
@@ -26,3 +26,23 @@
 .black-link:hover {
   color: black;
 }
+
+// for rounded grafics text
+.graph-less-25 {
+  color:#2460c8 !important;
+  margin-left: 2.4rem !important;
+  display: flex;
+  margin-top: 0px !important;
+}
+
+// for warnings. used in dashboard,
+.wott-warn-box {
+  padding: 10px;
+  background-color: #e9edf7;
+  color: #2460c8 !important;
+  font-size: .85rem !important;
+  margin: 1rem !important;
+  border-radius: 8px;
+  padding: 20px;
+  font-weight: 600;
+}

--- a/backend/device_registry/templates/dashboard.html
+++ b/backend/device_registry/templates/dashboard.html
@@ -145,7 +145,7 @@
           <div class="graphic-title">Weekly Progress</div>
           <div id="week-progress-100">  
             <span id="week-progress-var" style="width: {{ weekly_progress }}%">
-              <p class="mb-0 {% if weekly_progress < 5 %}graph-less-5{% endif %}" id="week-progres-text" >{{ weekly_progress }}</p>
+              <p class="my-0 {% if weekly_progress < 25 %}graph-less-25{% endif %}" id="week-progres-text" >{{ weekly_progress }}</p>
             </span>
           </div>
         </div>
@@ -229,19 +229,6 @@
     </section>
   </section>
 </div>
-<style>
-.graph-less-5 {
-  color:#2460c8 !important;
-  margin-left: 10px;
-  display: flex;
-  margin-top: 0px !important
-}
-
-.graph-less-5:after {
-  content:'%';
-}
-
-</style>
 {% endblock admin_content %}
 
 {% block scripts %}


### PR DESCRIPTION
### This PR change the color and the padding for the information inside the graphic weekly-progress.

---------

**The limit is 25% and until this percentage, the text stays inside the graph.**

![Captura de Tela 2020-02-14 às 14 31 19](https://user-images.githubusercontent.com/48695552/74546810-10b63080-4f43-11ea-9bb9-bae66429e1e3.png)

**Below 25% the info change color and position in order to be noticed inside the graph.**

![Captura de Tela 2020-02-14 às 14 27 56](https://user-images.githubusercontent.com/48695552/74546983-4ce99100-4f43-11ea-8731-0f5cb173647a.png)

close #711 
