### PR TITLE
Remove double % and remove hardcode info in nodes List

### DIFF
--- a/backend/device_registry/templates/dashboard.html
+++ b/backend/device_registry/templates/dashboard.html
@@ -38,7 +38,7 @@
           <div class="graphic-title wott-font-light-blue">Weekly Progress</div>
           <div id="week-progress-100">  
             <span id="week-progress-var-fake">
-              <p class="mb-0" id="week-progres-text">75%</p>
+              <p class="mb-0" id="week-progres-text">75</p>
             </span>
           </div>
         </div>

--- a/backend/device_registry/templates/root.html
+++ b/backend/device_registry/templates/root.html
@@ -143,26 +143,7 @@
               </tfoot>
 
               <tbody>
-
-              <!-------The rows should look like the one bellow -->
-                <tr role="row" class="odd"> 
-                  <td class="sorting_1 round" tabindex="0"> <!--ADDED ROUND-->
-                    <input type="checkbox" class="dt-checkbox wott-round-checkbox" id="index1"> <!--ADDED INDEX Must be unique added wott-round-checkbox-->
-                    <label for="index1"></label> <!--ADDED <label> for must match input id-->
-                  </td>
-                  <td><a href="/devices/1/">artem-linux-gf</a></td>
-                  <td>artem-linux-gf</td><td>3&nbsp;months, 2&nbsp;weeks ago</td>
-                  <td>
-                    <div class="position-relative">
-                      <div id="trust-progress-100" class="w-100" role="progressbar"></div> <!--added id=trust-score-100-->
-                      <span id="trust-progress-var" class="justify-content-center d-flex position-absolute">81%</span> <!--added id=trust-score-var-->
-                    </div>
-                  </td>
-                  <!-------Added wott-badge-pill-------->
-                  <td style=""><a class="wott-badge-pill" href="/devices/1/actions/" }="">2</a></td>
-                </tr>
-
-
+                <tr role="row" class="odd"></tr>
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
This PR removes the double % symbol in the Welcome Dashboard page.
This PR also removes one hardcode node in root.html, that could be seen before the data loads.



