### PR TITLE
Add target=_blank to all external links.

### DIFF
--- a/backend/device_registry/recommended_actions.py
+++ b/backend/device_registry/recommended_actions.py
@@ -87,15 +87,15 @@ class Action(NamedTuple):
 
     @property
     def short_html(self):
-        return markdown.markdown(self.short)
+        return markdown.markdown(self.short, extensions=['attr_list'])
 
     @property
     def long_html(self):
-        return markdown.markdown(self.long)
+        return markdown.markdown(self.long, extensions=['attr_list'])
 
     @property
     def terminal_title_html(self):
-        return markdown.markdown(self.terminal_title)
+        return markdown.markdown(self.terminal_title, extensions=['attr_list'])
 
     @property
     def severity_info(self):

--- a/backend/device_registry/templates/actions.html
+++ b/backend/device_registry/templates/actions.html
@@ -24,7 +24,7 @@
                       {{ action.title|safe }}
                       
                       {% if action.issue_url %}
-                        <a href="{{ action.issue_url }}"><i class="fab fa-github"></i></a>
+                        <a href="{{ action.issue_url }}" target="_blank"><i class="fab fa-github"></i></a>
                       {% endif %}
                     </span>
                   </div>

--- a/backend/device_registry/templates/admin_base.html
+++ b/backend/device_registry/templates/admin_base.html
@@ -113,7 +113,7 @@
             </div>
             <div class="col-6 text-right">
               <p class="mb-0">
-                &copy; 2020 - <a href="https://www.wott.io" class="text-muted">Web of Secure Things, Ltd</a>
+                &copy; 2020 - <a href="https://www.wott.io" class="text-muted" target="_blank">Web of Secure Things, Ltd</a>
               </p>
             </div>
           </div>

--- a/backend/device_registry/templates/cve.html
+++ b/backend/device_registry/templates/cve.html
@@ -103,7 +103,7 @@
             <tr class="row border-table">
               <td class="col-2 pl-3 pr-0 d-flex align-items-center medium-text font-weight-bold">
                 <span class="pr-3 bullet-lg {{ row.severity }} pb-1">&#8226</span>
-                <a href="{{ row.cve_link.href }}">{{ row.cve_link.text }}</a>
+                <a href="{{ row.cve_link.href }}" target="_blank">{{ row.cve_link.text }}</a>
               </td>
               <td class="col-2 d-flex align-items-center justify-content-center px-0 medium-text">{{ row.cve_date|date:"Y-m-d"|default:"N/A" }}</td>
               <td class="col-1 d-flex align-items-center font-strong {{ row.severity }} medium-text px-0">{{ row.severity }}</td>

--- a/backend/device_registry/templates/dashboard.html
+++ b/backend/device_registry/templates/dashboard.html
@@ -247,9 +247,9 @@
 
 <!-- HTML Obj with texts for Did you know box -->
 <div style="display:none" id="random-text-template">
-  <p class="wott-warn-box">Did you know that there are over 70,000 publicly exposed MongoDB servers on the internet according to<a class="font-weight-bolder wott-blue" href="https://www.shodan.io/"> Shodan</a>? Many, if not most, of these don't even require a password. <strong>Don't let this be you.</strong></p>
-  <p class="wott-warn-box">Did you know that there are over 57,000 publicly exposed Memcached servers on the internet according to<a class="font-weight-bolder wott-blue" href="https://www.shodan.io/"> Shodan</a>? These servers can include lots of sensitive data. <strong>Don't let this be you.</strong></p>
-  <p class="wott-warn-box">Did you know that there are over 640,000 publicly exposed Redis servers on the internet according to<a class="font-weight-bolder wott-blue" href="https://www.shodan.io/"> Shodan</a>? These servers can include lots of sensitive data. <strong>Don't let this be you.</strong></p>
+  <p class="wott-warn-box">Did you know that there are over 70,000 publicly exposed MongoDB servers on the internet according to<a class="font-weight-bolder wott-blue" href="https://www.shodan.io/" target="_blank"> Shodan</a>? Many, if not most, of these don't even require a password. <strong>Don't let this be you.</strong></p>
+  <p class="wott-warn-box">Did you know that there are over 57,000 publicly exposed Memcached servers on the internet according to<a class="font-weight-bolder wott-blue" href="https://www.shodan.io/" target="_blank"> Shodan</a>? These servers can include lots of sensitive data. <strong>Don't let this be you.</strong></p>
+  <p class="wott-warn-box">Did you know that there are over 640,000 publicly exposed Redis servers on the internet according to<a class="font-weight-bolder wott-blue" href="https://www.shodan.io/" target="_blank"> Shodan</a>? These servers can include lots of sensitive data. <strong>Don't let this be you.</strong></p>
 </div>
 
 {% endblock admin_content %}

--- a/backend/recommended_actions.yaml
+++ b/backend/recommended_actions.yaml
@@ -49,14 +49,14 @@
 
     * FTPS uses certificates to encrypt communication (similar to public key authentication). Certain tools allow certificates to be requested and created.
     * When a trusted certificate authority signs these certificates, it acts as an ensurer that the client is being connected to a trusted and secure server. This can prevent a Man-in-the-Middle attack.
-    * Learn more about FTPS [here](https://www.serv-u.com/solutions/what-is-file-transfer-protocol-secure).
+    * Learn more about FTPS [here](https://www.serv-u.com/solutions/what-is-file-transfer-protocol-secure){{: target="_blank"}}.
 
     We do recommend SFTP as that is the easiest to setup and has a decent level of security. Depending on the size of your organisation and resources it can offer, FTPS can be a formidable line of defense to protect your data.
 
     Two of the tried and tested services that we recommend are:
 
-    [proftpd](http://proftpd.org)
-    [vsftpd](https://help.ubuntu.com/community/vsftpd)
+    [proftpd](http://proftpd.org){{: target="_blank"}}
+    [vsftpd](https://help.ubuntu.com/community/vsftpd){{: target="_blank"}}
   terminal_title: |
     To uninstall your FTP server, run the following command:
   terminal_code: |
@@ -92,7 +92,8 @@
   long: |
     SSH (Secure Shell) is a method to remote login to a server. SSH is usually secure, however if used with the default settings, can be vulnerable to attacks from unwanted parties. By default, the SSH config file is preset with some values allowing for new developers to get used to setting up SSH servers. However, this often exposes vulnerabilities by not being restrictive enough.
 
-    We've detected that `AllowAgentForwarding` is enabled. This means that you can SSH into one host and from there to a different host using the SSH key on your local machine. This might be the case if you cannot directly access the final host (for instance if you're using a [Bastion host](https://en.wikipedia.org/wiki/Bastion_host)). However, doing so leaves a socket open on the server, which then can be attacked.
+    We've detected that `AllowAgentForwarding` is enabled. This means that you can SSH into one host and from there to a different host using the SSH key on your local machine. This might be the case if you cannot directly access the final host (for instance if you're using a
+    [Bastion host](https://en.wikipedia.org/wiki/Bastion_host)){{: target="_blank"}}. However, doing so leaves a socket open on the server, which then can be attacked.
 
     Unless you need this feature, we recommend you disable this feature by edit the `/etc/ssh/sshd_config` file like so:
 
@@ -100,7 +101,8 @@
     AllowAgentForwarding no
     ```
 
-    For more information on how to secure OpenSSH, see our larger tutorial [here](https://wott.io/blog/tutorials/2019/10/25/audit-openssh-security).
+    For more information on how to secure OpenSSH, see our larger tutorial
+    [here](https://wott.io/blog/tutorials/2019/10/25/audit-openssh-security){{: target="_blank"}}.
   terminal_title: |
     Here are the steps to resolve this issue.
   terminal_code: |
@@ -126,11 +128,14 @@
 
     Once you've updated the configuration, make sure to restart the SSH server using `sudo service ssh restart`.
 
-    For more information on how to secure OpenSSH, see our larger tutorial [here](https://wott.io/blog/tutorials/2019/10/25/audit-openssh-security).
+    For more information on how to secure OpenSSH, see our larger tutorial
+    [here](https://wott.io/blog/tutorials/2019/10/25/audit-openssh-security){{: target="_blank"}}.
   terminal_title: |
     Here are the steps to resolve this issue.
 
-      **Warning:** Before you disable password authentication, make sure that you have [generated and installed](https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys-on-ubuntu-1604) your SSH keys on the remote server. Failure to do so will result in that you will be locked out of your server.
+      **Warning:** Before you disable password authentication, make sure that you have
+      [generated and installed](https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys-on-ubuntu-1604){{: target="_blank"}}
+      your SSH keys on the remote server. Failure to do so will result in that you will be locked out of your server.
 
   terminal_code: |
     $ sudo wott-agent patch openssh-password-auth
@@ -152,7 +157,8 @@
 
     Once you've updated the configuration, make sure to restart the SSH server using `sudo service ssh restart`.
 
-    For more information on how to secure OpenSSH, see our larger tutorial [here](https://wott.io/blog/tutorials/2019/10/25/audit-openssh-security).
+    For more information on how to secure OpenSSH, see our larger tutorial
+    [here](https://wott.io/blog/tutorials/2019/10/25/audit-openssh-security){{: target="_blank"}}.
 
     **Reference:** CIS Ubuntu 16.04 LTS Benchmarks v1.1.0 (section 5.2.8)
 
@@ -178,7 +184,8 @@
     PermitEmptyPasswords no
     ```
 
-    For more information on how to secure OpenSSH, see our larger tutorial [here](https://wott.io/blog/tutorials/2019/10/25/audit-openssh-security).
+    For more information on how to secure OpenSSH, see our larger tutorial
+    [here](https://wott.io/blog/tutorials/2019/10/25/audit-openssh-security){{: target="_blank"}}.
 
     **Reference**: CIS Ubuntu 16.04 LTS Benchmarks v1.1.0 (section 5.2.9)
 
@@ -204,7 +211,8 @@
     Protocol 2
     ```
 
-    For more information on how to secure OpenSSH, see our larger tutorial [here](https://wott.io/blog/tutorials/2019/10/25/audit-openssh-security).
+    For more information on how to secure OpenSSH, see our larger tutorial
+    [here](https://wott.io/blog/tutorials/2019/10/25/audit-openssh-security){{: target="_blank"}}.
 
     **Reference:** CIS Ubuntu 16.04 LTS Benchmarks v1.1.0 (section 5.2.2)
 
@@ -233,7 +241,8 @@
 
     Once installed, you can then run `sudo dpkg-reconfigure unattended-upgrades` to configure your preferences. For most installations, the defaults should be fine.
 
-    For more detail, you can see [here](https://wiki.debian.org/UnattendedUpgrades) for Debian or [here](https://help.ubuntu.com/lts/serverguide/automatic-updates.html) for Ubuntu.
+    For more detail, you can see [here](https://wiki.debian.org/UnattendedUpgrades){{: target="_blank"}}
+    for Debian or [here](https://help.ubuntu.com/lts/serverguide/automatic-updates.html){{: target="_blank"}} for Ubuntu.
 
     ## Amazon Linux / RedHat Enterprise Linux (RHEL) / CentOS
 
@@ -272,11 +281,13 @@
   class: PubliclyAccessibleServiceAction
   param: mongod
   short: |
-    We detected that a MongoDB instance may be accessible remotely. This may allow a remote attacker to gain access to your database and leak customer data. According to [Shodan](https://www.shodan.io/), there are over 70,000 publicly exposed MongoDB servers. Don't be one of them. Consider either blocking port 27017 through the WoTT firewall management tool, or reconfigure MongoDB to only listen on localhost.
+    We detected that a MongoDB instance may be accessible remotely. This may allow a remote attacker to gain access to your database and leak customer data. According to
+    [Shodan](https://www.shodan.io/){{: target="_blank"}}, there are over 70,000 publicly exposed MongoDB servers. Don't be one of them. Consider either blocking port 27017 through the WoTT firewall management tool, or reconfigure MongoDB to only listen on localhost.
   long: |
     MongoDB is a widely used NoSQL database. Unfortunately, the default configuration in MongoDB until relatively recently was to bind on all public interfaces (rather than just localhost). Because of this, many MongoDB servers were made publicly accessible. To make matters worse, by default, MongoDB does not require any authentication, meaning that the potential attacker only needed to know the public IP of the server in order to connect and access your customer data.
 
-    We recommend that you either reconfigure your MongoDB instance to only listen on localhost (assuming the appserver talking to MongoDB runs on the same server), or creating a firewall policy to only allow connections from your appservers to port 27017 on your node. You can do the latter using WoTT's firewall management tool. You can read more about MongoDB's ports [here](https://docs.mongodb.com/manual/reference/default-mongodb-port/).
+    We recommend that you either reconfigure your MongoDB instance to only listen on localhost (assuming the appserver talking to MongoDB runs on the same server), or creating a firewall policy to only allow connections from your appservers to port 27017 on your node. You can do the latter using WoTT's firewall management tool. You can read more about MongoDB's ports
+    [here](https://docs.mongodb.com/manual/reference/default-mongodb-port/){{: target="_blank"}}.
 
     Start by locating your MongoDB configuration file
     ```
@@ -385,7 +396,8 @@
   class: PubliclyAccessibleServiceAction
   param: memcached
   short: |
-    Your Memcached instance may be accessible remotely. This is likely due to use of a default configuration. According to [Shodan](https://www.shodan.io/), there are over 57,000 publicly exposed Memcached servers on the internet. We recommend that you reconfigure this service to avoid leaking customer data.
+    Your Memcached instance may be accessible remotely. This is likely due to use of a default configuration. According to
+    [Shodan](https://www.shodan.io/){{: target="_blank"}}, there are over 57,000 publicly exposed Memcached servers on the internet. We recommend that you reconfigure this service to avoid leaking customer data.
   long: |
     Memcached is a popular caching server. By default, many Memcached configurations will listen on all interfaces. This may be desirable in some configurations (e.g. when you have other services on the network that needs to talk to Memcached). In that case, we recommend that you create a firewall policy that only allows these servers to access Memcached. If however you only use Memcached locally, we recommend that you reconfigure Memcached to only listen on the loopback (localhost) interface.
 
@@ -413,9 +425,11 @@
 - title: System contains Meltdown and/or Spectre vulnerabilities
   class: CpuVulnerableAction
   short: |
-    Your system appears to be vulnerable to the [Meltdown](https://meltdownattack.com/meltdown.pdf) and [Spectre](https://spectreattack.com/spectre.pdf) attacks. This could compromise your data by allowing unwanted access to sensitive data through bypassing hardware restrictions.
+    Your system appears to be vulnerable to the [Meltdown](https://meltdownattack.com/meltdown.pdf){{: target="_blank"}}
+    and [Spectre](https://spectreattack.com/spectre.pdf){{: target="_blank"}} attacks. This could compromise your data by allowing unwanted access to sensitive data through bypassing hardware restrictions.
   long: |
-    [Meltdown](https://meltdownattack.com/meltdown.pdf) and [Spectre](https://spectreattack.com/spectre.pdf) vulnerabilities were found in 2018, effectively affecting every computer-based hardware manufactured in the last 20 years. There are 3 common vulnerabilities, 2 encompass what is known as Spectre; the other is Meltdown. If exploited, these vulnerabilities could allow for access to what was previously thought of as protected data.
+    [Meltdown](https://meltdownattack.com/meltdown.pdf){{: target="_blank"}} and
+    [Spectre](https://spectreattack.com/spectre.pdf){{: target="_blank"}} vulnerabilities were found in 2018, effectively affecting every computer-based hardware manufactured in the last 20 years. There are 3 common vulnerabilities, 2 encompass what is known as Spectre; the other is Meltdown. If exploited, these vulnerabilities could allow for access to what was previously thought of as protected data.
 
     Meltdown bypasses hardware security boundaries between applications and the operating systems and uses this to gain access to memory based on 'out of order' sequencing. Intel chips manufactured since 2010 were reported to be vulnerable to these issues. Spectre also acts at a hardware level by essentially 'tricking' a program into executing a sequence it wouldn't normally by exploiting the speculative logic systems in a chip.
 
@@ -437,7 +451,8 @@
   class: PubliclyAccessibleServiceAction
   param: redis-server
   short: |
-    Your Redis instance may be publicly accessible. This could cause accidental customer data leakage. According to [Shodan](https://www.shodan.io/), there are over 640,000 publicly exposed Redis servers on the internet. Consider re-configuring your Redis to listen only on the localhost, or add a lock down the access to Redis using a firewall if it needs to be accessible on the network.
+    Your Redis instance may be publicly accessible. This could cause accidental customer data leakage. According to
+    [Shodan](https://www.shodan.io/){{: target="_blank"}}, there are over 640,000 publicly exposed Redis servers on the internet. Consider re-configuring your Redis to listen only on the localhost, or add a lock down the access to Redis using a firewall if it needs to be accessible on the network.
   long: |
     Redis is an open-source data store with several uses, but most often used for caching. Unfortunately, Redis does not have any robust security features of its own, and is intended for use by trusted clients in a trusted network. It is therefore not recommended to have a Redis instance exposed over the internet.
 
@@ -473,7 +488,8 @@
 
     WoTT can detect an out-of-date or insecure package and alert you about this. Do however note that in some instances, there is a known vulnerabilities that have been identified, but yet to be patched by the operating system vendors.
 
-    Also, for those new to security, it is worth pointing out that when a security issue is reported and identified, it is reported into the Common Vulnerabilities and Exposures (CVE) database. The most common authority for this is the [mitre](https://cve.mitre.org/) CVE database.
+    Also, for those new to security, it is worth pointing out that when a security issue is reported and identified, it is reported into the Common Vulnerabilities and Exposures (CVE) database. The most common authority for this is the
+    [mitre](https://cve.mitre.org/){{: target="_blank"}} CVE database.
 
 - title: Enable our GitHub integration for improved workflow
   class: GithubAction
@@ -491,15 +507,16 @@
   short: |
     WoTT uses an agent to perform the security audit. Without the agent installed on any of your servers, we are unable to provide you with any insights on your security posture.
   long: |
-    To get started, you need to install our [agent](https://github.com/WoTTsecurity/agent) on your servers. The agent performs a security audit, which is then sent to our back-end for processing. With this data, we are able to provide you with tailored recommendations for how to improve your security posture.
+    To get started, you need to install our [agent](https://github.com/WoTTsecurity/agent){{: target="_blank"}} on your servers. The agent performs a security audit, which is then sent to our back-end for processing. With this data, we are able to provide you with tailored recommendations for how to improve your security posture.
 
     For the security minded people, we are happy to let you know that the agent is fully open source, so you can inspect the code base before you install it if you so desire.
 
-    While the installation instructions below are useful for installing on small number of hosts, we also have an [Ansible Playbook](https://github.com/WoTTsecurity/examples/tree/master/ansible) if you want to deploy the agent to a larger fleet of servers.
+    While the installation instructions below are useful for installing on small number of hosts, we also have an
+    [Ansible Playbook](https://github.com/WoTTsecurity/examples/tree/master/ansible){{: target="_blank"}} if you want to deploy the agent to a larger fleet of servers.
   terminal_title: |
     To install the agent, run the following command:
 
-    [Supported Operating Systems](https://github.com/WoTTsecurity/agent#supported-operating-systems)
+    [Supported Operating Systems](https://github.com/WoTTsecurity/agent#supported-operating-systems){{: target="_blank"}}
   terminal_code: |
     $ export CLAIM_TOKEN="{key}"
     $ curl -sL https://install.wott.io | sudo -E bash


### PR DESCRIPTION
*Note*: All external links in Markdown text for Recommended Actions should have `{{: target="_blank"}}` appended, like so:
`[the link](https://wott.io){{: target="_blank"}}`

This is then converted to `{: target="_blank"}` which is a [Markdown extension syntax](https://python-markdown.github.io/extensions/attr_list/) for defining HTML attribute. In this case it's a `target="_blank"` attribute of `<a>`.